### PR TITLE
Infection Teams

### DIFF
--- a/.idea/artifacts/Infection_jar.xml
+++ b/.idea/artifacts/Infection_jar.xml
@@ -1,0 +1,9 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="Infection:jar">
+    <output-path>$PROJECT_DIR$/out/artifacts/Infection_jar</output-path>
+    <root id="archive" name="Infection.jar">
+      <element id="module-output" name="Infection.main" />
+      <element id="file-copy" path="$PROJECT_DIR$/src/main/resources/plugin.yml" />
+    </root>
+  </artifact>
+</component>

--- a/src/main/java/org/yanmachine/infection/infectionGameUtility/infectionTeams.java
+++ b/src/main/java/org/yanmachine/infection/infectionGameUtility/infectionTeams.java
@@ -1,0 +1,41 @@
+package org.yanmachine.infection.infectionGameUtility;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
+
+public class infectionTeams {
+    /**
+     * Initializes 2 basic teams for the game
+     */
+    public static void setUp() {
+        createTeam("Infected", "RED", ChatColor.RED + "Infected");
+        createTeam("Uninfected", "GREEN", ChatColor.GREEN + "Uninfected");
+    }
+
+    /**
+     * Used to create teams
+     * Note: If new games added, this class should be separate from infectionTeams
+     * @param teamName name of team/ how to access it
+     * @param colour colour of display in game
+     * @param displayName display name in game
+     */
+    public static void createTeam(String teamName, String colour, String displayName) {
+        Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+
+        //This checks for duplicate teams, even though as of now there will only ever be 2 teams
+        if (!scoreboard.getTeams().contains(scoreboard.getTeam(teamName))){
+            Team newTeam = scoreboard.registerNewTeam(teamName);
+            if (colour.equalsIgnoreCase("RED")) {
+                newTeam.setColor(ChatColor.RED);
+            }
+            else{
+                newTeam.setColor(ChatColor.GREEN);
+            }
+            newTeam.setDisplayName(displayName);
+
+        }
+    }
+
+}


### PR DESCRIPTION
Basic teams set up for infection game mode.
Teams have colours to differentiate and currently are initialized on start up.
Note: setColor, ChatColor and setDisplayName are deprecated and must be updated